### PR TITLE
Desempate seguindo a ordem dos critérios #530

### DIFF
--- a/views/pdf/technical-category.php
+++ b/views/pdf/technical-category.php
@@ -16,7 +16,8 @@
     }
     if($type == "technicalna" && isset($preliminary)){
         $sub = Pdf::sortArrayForNAEvaluations($sub, $opp);
-    }else{
+    }else if(!isset($preliminary)){}
+    else{
         usort($sub, 'invenDescSort');
     }
 ?>

--- a/views/pdf/technical-category.php
+++ b/views/pdf/technical-category.php
@@ -12,10 +12,12 @@
 
     function invenDescSort($item1,$item2){
         if ($item1->consolidatedResult == $item2->consolidatedResult) return 0;
-        return ($item1->consolidatedResult < $item2->consolidatedResult) ? 1 : -1;
+        return ($item1->consolidatedResult < $item2->consolidatedResult) ? -1 : 1;
     }
     if($type == "technicalna" && isset($preliminary)){
         $sub = Pdf::sortArrayForNAEvaluations($sub, $opp);
+    }else{
+        usort($sub, 'invenDescSort');
     }
 ?>
 <div class="container">

--- a/views/pdf/technical-category.php
+++ b/views/pdf/technical-category.php
@@ -14,9 +14,9 @@
         if ($item1->consolidatedResult == $item2->consolidatedResult) return 0;
         return ($item1->consolidatedResult < $item2->consolidatedResult) ? 1 : -1;
     }
-    usort($sub,'invenDescSort');
-    
-  
+    if($type == "technicalna" && isset($preliminary)){
+        $sub = Pdf::sortArrayForNAEvaluations($sub, $opp);
+    }
 ?>
 <div class="container">
     <?php 


### PR DESCRIPTION
Responsáveis:  @pedrovitor074 

Linked Issue:  https://github.com/EscolaDeSaudePublica/mapadasaude/issues/530

### Descrição

Sistema de desempate para o edital do cuidar melhor



### 🖥 Passos a passo para teste

1. Criar oportunidade
2. realizar inscrição e avaliações
3. comparação das notas após o empate


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
