### PR TITLE
Nome dos candidatos com letras maiúsculas

### DIFF
--- a/layouts/parts/reports/button-print.php
+++ b/layouts/parts/reports/button-print.php
@@ -1,3 +1,7 @@
-<a href="<?php echo $app->createUrl('pdf', 'minha_inscricao/' . $id); ?>" class="btn btn-default" target="_blank">
-    <i class="fa fa-file-pdf-o" aria-hidden="true"></i> Imprimir inscrição em PDF
-</a>
+<div class="pdf-report-btn">
+<?php $this->applyTemplateHook('pdf-report-btn','before') ?>
+    <a href="<?php echo $app->createUrl('pdf', 'minha_inscricao/' . $id); ?>" class="btn btn-default" target="_blank" title="Imprima seu formulário em PDF">
+        Imprimir em PDF
+    </a>
+    <?php $this->applyTemplateHook('pdf-report-btn','after') ?>
+</div>

--- a/views/pdf/simple-documentary-category.php
+++ b/views/pdf/simple-documentary-category.php
@@ -32,7 +32,7 @@
                         ?>
                         <tr>
                             <td class="text-left"><?php echo $nameSub->number; ?></td>
-                            <td class="text-left"><?php echo $nameSub->owner->name; ?></td>
+                            <td class="text-left"><?php echo mb_strtoupper($nameSub->owner->name); ?></td>
                             <td class="text-center"><?php echo RegistrationStatus::getStatusNameById($nameSub->status); ?> </td>
                         </tr>
                     <?php

--- a/views/pdf/simple-documentary-no-category.php
+++ b/views/pdf/simple-documentary-no-category.php
@@ -24,7 +24,7 @@
                     $arrayCheck[] = $nameSub->category;?>
                     <tr>
                         <td class="text-left"><?php echo $nameSub->number; ?></td>
-                        <td class="text-left"><?php echo $nameSub->owner->name; ?></td>
+                        <td class="text-left"><?php echo mb_strtoupper($nameSub->owner->name); ?></td>
                         <td class="text-center"><?php echo RegistrationStatus::getStatusNameById($nameSub->status); ?> </td>
                     </tr>
                 <?php

--- a/views/pdf/technical-category.php
+++ b/views/pdf/technical-category.php
@@ -68,7 +68,7 @@
                                 <?php }
                             ?>
                             <td class="text-left"><?php echo $nameSub->number; ?></td>
-                            <td class="text-left"><?php echo $nameSub->owner->name; ?></td>
+                            <td class="text-left"><?php echo mb_strtoupper($nameSub->owner->name); ?></td>
                             <?php 
                                 if($type == "technicalna" && !isset($preliminary)){ ?>
                                     <td class="text-center"><?php echo $nameSub->preliminaryResult; ?></td>

--- a/views/pdf/technical-no-category.php
+++ b/views/pdf/technical-no-category.php
@@ -40,7 +40,7 @@
                             <?php }
                         ?>
                         <td class="text-left"><?php echo $nameSub->number; ?></td>
-                        <td class="text-left"><?php echo $nameSub->owner->name; ?></td>
+                        <td class="text-left"><?php echo mb_strtoupper($nameSub->owner->name); ?></td>
                         <td class="text-center"><?php echo !isset($preliminary) ? $nameSub->preliminaryResult : $nameSub->consolidatedResult; ?></td>
                     </tr>
                 <?php


### PR DESCRIPTION
### Contexto
No relatório que são gerados em formato PDF, o nome dos candidatos estavam sendo gerado de acordo como foi cadastrado, ou seja, letras maiúsculas e letras minusculas.
Sendo assim, para padronizar, é melhor colocar todas com o formato de letras maiúsculas.

### Teste para funcionalidade
Gerar um relatório em pdf e verificar se o nome dos candidatos estão com o formato de letras maiúsculas.